### PR TITLE
Fix AttributeError when SSLStream is used

### DIFF
--- a/redio/protocol.py
+++ b/redio/protocol.py
@@ -70,7 +70,16 @@ class Protocol:
             if self.inbuf:
                 raise ProtocolError(
                     f"Pipelining error: previous bytes unread: {self.inbuf[:10000]}")
-            if self.sock.socket.is_readable():
+            
+            if hasattr(self.sock, "transport_stream"):
+                # If the socket stream is wrapped with an SSL stream,
+                # the former one can be retrieved as `transport_stream`
+                # argument, see:
+                # https://github.com/python-trio/trio/blob/master/trio/_ssl.py
+                raw_socket = self.sock.transport_stream.socket
+            else:
+                raw_socket = self.sock.socket
+            if raw_socket.is_readable():
                 raise ProtocolError(
                     f"Pipelining error: server sent unexpected data"
                 )


### PR DESCRIPTION
This fixes following error when using TLS/SSL:

```text
File "/usr/local/lib/python3.8/site-packages/redio/highlevel.py", line 75, in _run
  await self.protocol.connect()
File "/usr/local/lib/python3.8/site-packages/redio/protocol.py", line 26, in connect
  await self.AUTH(self.conninfo.password.encode())
File "/usr/local/lib/python3.8/site-packages/redio/protocol.py", line 52, in run_single
  ret, = await self.run([cmd])
File "/usr/local/lib/python3.8/site-packages/redio/protocol.py", line 73, in run
  if self.sock.socket.is_readable():
File "/usr/local/lib/python3.8/site-packages/trio/_ssl.py", line 411, in __getattr__
  raise AttributeError(name)
AttributeError: socket
```